### PR TITLE
Ci/fix macos future error

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,14 +16,14 @@ Imports:
     dplyr (>= 1.1.4),
     hubExamples (>= 0.1.0),
     hubEvals (>= 0.0.0.9001),
-    hubEnsembles (>= 0.1.9)
-Depends: 
-    R (>= 2.10)
-Suggests: 
-    testthat (>= 3.0.0),
+    hubEnsembles (>= 0.1.9),
     purrr (>= 1.0.4),
     furrr (>= 0.3.1),
     future (>= 1.49.0)
+Depends: 
+    R (>= 2.10)
+Suggests: 
+    testthat (>= 3.0.0)
 Config/testthat/edition: 3
 Remotes:
     hubverse-org/hubUtils,

--- a/R/model_importance.R
+++ b/R/model_importance.R
@@ -81,8 +81,14 @@
 #' across all component model outputs for each unique `output_type_id`.
 #' This can be `median` or a custom function (e.g., geometric_mean. Details
 #' can be found in
-#' https://hubverse-org.github.io/hubEnsembles/articles/hubEnsembles.html)
+#' https://hubverse-org.github.io/hubEnsembles/articles/hubEnsembles.html).
+#'
+#' This function uses the `furrr` and `future` for parallelization.
+#' To enable parallel execution, please set a parallel backend, e.g., via
+#' `future::plan()`.
+#'
 #' @examples \dontrun{
+#' future::plan(future::multisession)
 #' library(dplyr)
 #' library(hubExamples)
 #' forecast_data <- hubExamples::forecast_outputs |>

--- a/R/score_untrained.R
+++ b/R/score_untrained.R
@@ -31,7 +31,7 @@ score_untrained <- function(single_task_data, oracle_output_data, model_id_list,
                             ensemble_fun, importance_algorithm, subset_wt,
                             metric, ...) {
   # check if the necessary packages are installed
-  if (is(plan(), "sequential")) {
+  if (is(future::plan(), "sequential")) {
     message(
       "Note: This function uses 'furrr' and 'future' for parallelization.\n",
       "To enable parallel execution, please set future::plan(multisession)."

--- a/R/score_untrained.R
+++ b/R/score_untrained.R
@@ -147,10 +147,17 @@ score_untrained <- function(single_task_data, oracle_output_data, model_id_list,
     ## Environment for parallel computation
     # store the original plan
     original_plan <- future::plan()
+    os <- Sys.info()[["sysname"]]
+    ci <- tolower(Sys.getenv("CI", "false")) == "true"
     # set parallel plan with a conservative number of workers
-    future::plan(future::multisession,
-      workers = min(4, parallel::detectCores() - 1)
-    )
+    if (ci && os == "Darwin") {
+      future::plan(future::sequential)
+      message("CI macOS – using sequential")
+    } else {
+      future::plan(future::multisession,
+        workers = min(4, parallel::detectCores() - 1)
+      )
+    }
     # restore the original plan on exit
     on.exit(future::plan(original_plan), add = TRUE)
 

--- a/R/score_untrained.R
+++ b/R/score_untrained.R
@@ -30,6 +30,14 @@
 score_untrained <- function(single_task_data, oracle_output_data, model_id_list,
                             ensemble_fun, importance_algorithm, subset_wt,
                             metric, ...) {
+  # check if the necessary packages are installed
+  if (is(plan(), "sequential")) {
+    message(
+      "Note: This function uses 'furrr' and 'future' for parallelization.\n",
+      "To enable parallel execution, please set future::plan(multisession)."
+    )
+  }
+
   # models in the single_task_data
   models <- unique(single_task_data$model_id)
   missing_model <- setdiff(model_id_list, single_task_data$model_id)
@@ -46,7 +54,7 @@ score_untrained <- function(single_task_data, oracle_output_data, model_id_list,
       ...
     )
     # build ensemble forecasts by leaving one model out
-    ens_lomo <- lapply(models, function(x) {
+    ens_lomo <- furrr::future_map(models, function(x) {
       single_task_data |>
         dplyr::filter(.data$model_id != x) |>
         ens_fun(
@@ -81,16 +89,6 @@ score_untrained <- function(single_task_data, oracle_output_data, model_id_list,
       select(-c("output_type_id", "value")) |>
       distinct()
   } else {
-    # check if the necessary packages are installed
-    if (!requireNamespace("furrr", quietly = TRUE)) {
-      stop("Please install `furrr` package for parallel execution in `lasomo`
-           algorithm.")
-    }
-    if (!requireNamespace("future", quietly = TRUE)) {
-      stop("Please install `future` package for parallel execution in `lasomo`
-           algorithm.")
-    }
-
     # number of models
     n <- length(models)
     # Power set of {1,2,...,n} not including the empty set.
@@ -143,23 +141,6 @@ score_untrained <- function(single_task_data, oracle_output_data, model_id_list,
           distinct(),
         by = "model_id"
       )
-
-    ## Environment for parallel computation
-    # store the original plan
-    original_plan <- future::plan()
-    os <- Sys.info()[["sysname"]]
-    ci <- tolower(Sys.getenv("CI", "false")) == "true"
-    # set parallel plan with a conservative number of workers
-    if (ci && os == "Darwin") {
-      future::plan(future::sequential)
-      message("CI macOS – using sequential")
-    } else {
-      future::plan(future::multisession,
-        workers = min(4, parallel::detectCores() - 1)
-      )
-    }
-    # restore the original plan on exit
-    on.exit(future::plan(original_plan), add = TRUE)
 
     ## parallel computation
     # calculate importance scores

--- a/man/model_importance.Rd
+++ b/man/model_importance.Rd
@@ -116,10 +116,15 @@ Default is \code{mean}, meaning that equally (or weighted) mean is calculated
 across all component model outputs for each unique \code{output_type_id}.
 This can be \code{median} or a custom function (e.g., geometric_mean. Details
 can be found in
-https://hubverse-org.github.io/hubEnsembles/articles/hubEnsembles.html)
+https://hubverse-org.github.io/hubEnsembles/articles/hubEnsembles.html).
+
+This function uses the \code{furrr} and \code{future} for parallelization.
+To enable parallel execution, please set a parallel backend, e.g., via
+\code{future::plan()}.
 }
 \examples{
 \dontrun{
+future::plan(future::multisession)
 library(dplyr)
 library(hubExamples)
 forecast_data <- hubExamples::forecast_outputs |>

--- a/man/score_untrained.Rd
+++ b/man/score_untrained.Rd
@@ -86,5 +86,9 @@ Default is \code{mean}, meaning that equally (or weighted) mean is calculated
 across all component model outputs for each unique \code{output_type_id}.
 This can be \code{median} or a custom function (e.g., geometric_mean. Details
 can be found in
-https://hubverse-org.github.io/hubEnsembles/articles/hubEnsembles.html)
+https://hubverse-org.github.io/hubEnsembles/articles/hubEnsembles.html).
+
+This function uses the \code{furrr} and \code{future} for parallelization.
+To enable parallel execution, please set a parallel backend, e.g., via
+\code{future::plan()}.
 }

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -1,3 +1,0 @@
-if (nzchar(Sys.getenv("CI"))) {
-  future::plan("sequential")
-}

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -1,0 +1,3 @@
+if (nzchar(Sys.getenv("CI"))) {
+  future::plan("sequential")
+}

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,5 +1,7 @@
-if (Sys.getenv("CI") == "true" && Sys.info()["sysname"] == "Darwin") {
-        future::plan(sequential)
-} else {
-        future::plan(multisession)
+if (requireNamespace("future", quietly = TRUE)) {
+  if (Sys.getenv("CI") == "true" && Sys.info()["sysname"] == "Darwin") {
+    future::plan(future::sequential)
+  } else {
+    future::plan(future::multisession)
+  }
 }

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,5 +1,8 @@
 if (requireNamespace("future", quietly = TRUE)) {
-  if (Sys.getenv("CI") == "true" && Sys.info()["sysname"] == "Darwin") {
+  os <- Sys.info()[["sysname"]]
+  ci <- tolower(Sys.getenv("CI", "false")) == "true"
+
+  if (ci) {
     future::plan(future::sequential)
   } else {
     future::plan(future::multisession)

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -2,13 +2,16 @@ if (requireNamespace("future", quietly = TRUE)) {
   os <- Sys.info()[["sysname"]]
   ci <- tolower(Sys.getenv("CI", "false")) == "true"
 
-  if (ci) {
+  if (ci && os == "Darwin") {
     future::plan(future::sequential)
+    message("CI macOS detected – using future::sequential")
   } else {
     future::plan(future::multisession)
+    message("Using future::multisession")
   }
 }
 
 if (Sys.getenv("GITHUB_ACTIONS") == "true") {
   future::plan("sequential")
+  message("GITHUB_ACTIONS detected – using future::sequential")
 }

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -8,3 +8,7 @@ if (requireNamespace("future", quietly = TRUE)) {
     future::plan(future::multisession)
   }
 }
+
+if (Sys.getenv("GITHUB_ACTIONS") == "true") {
+  future::plan("sequential")
+}

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,0 +1,5 @@
+if (Sys.getenv("CI") == "true" && Sys.info()["sysname"] == "Darwin") {
+        future::plan(sequential)
+} else {
+        future::plan(multisession)
+}

--- a/tests/testthat/test-score_untrained-lasomo.R
+++ b/tests/testthat/test-score_untrained-lasomo.R
@@ -6,6 +6,7 @@ library(hubEvals)
 library(purrr)
 library(furrr)
 library(future)
+future::plan("sequential") # Set up sequential plan for testing
 
 # forecast data list
 file_names <- c(


### PR DESCRIPTION
Created the /tests/testthat/setup.R file and made the following changes:

- score_untrained(): Removed internal parallel backend setup, applied parallel execution in `lomo` as well. Instead, I added details on setting the parallel backend setup in the 'model_importance()'.
- model_importance(): Included guidance for `future::plan()` setup in `@details`.
- DESCRIPTION: moved `furrr, purrr, future` from `Suggests:` to `Imports:`
