### PR TITLE
Issue/20250725misc

### DIFF
--- a/R/model_importance.R
+++ b/R/model_importance.R
@@ -88,7 +88,6 @@
 #' `future::plan()`.
 #'
 #' @examples \dontrun{
-#' future::plan(future::multisession)
 #' library(dplyr)
 #' library(hubExamples)
 #' forecast_data <- hubExamples::forecast_outputs |>

--- a/R/model_importance.R
+++ b/R/model_importance.R
@@ -221,7 +221,7 @@ model_importance <- function(forecast_data,
       )) |>
       group_by(model_id) |>
       summarise(mean_importance = mean(importance), .groups = "drop") |>
-      arrange(desc(mean_importance))
+      arrange(desc("mean_importance"))
   } else if (na_action == "average") {
     importance_result <- score_result |>
       group_by(location, horizon, target_end_date) |>
@@ -231,13 +231,13 @@ model_importance <- function(forecast_data,
       )) |>
       group_by(model_id) |>
       summarise(mean_importance = mean(importance), .groups = "drop") |>
-      arrange(desc(mean_importance))
+      arrange(desc("mean_importance"))
   } else {
     importance_result <- score_result |>
       filter(!is.na(importance)) |>
       group_by(model_id) |>
       summarise(mean_importance = mean(importance), .groups = "drop") |>
-      arrange(desc(mean_importance))
+      arrange(desc("mean_importance"))
   }
 
   return(importance_result)

--- a/R/model_importance.R
+++ b/R/model_importance.R
@@ -152,7 +152,7 @@ model_importance <- function(forecast_data,
 
   # Give a message for the user to check the forecast dates
   message(sprintf(
-    "The input data has forecast from %s to %s: a total of %d forecast dates.",
+    "Forecasts from %s to %s (a total of %d forecast date(s)).",
     min(forecast_date_list), max(forecast_date_list), length(forecast_date_list)
   ))
 
@@ -221,7 +221,8 @@ model_importance <- function(forecast_data,
         ~ coalesce(., min(., na.rm = TRUE))
       )) |>
       group_by(model_id) |>
-      summarise(mean_importance = mean(importance), .groups = "drop")
+      summarise(mean_importance = mean(importance), .groups = "drop") |>
+      arrange(desc(mean_importance))
   } else if (na_action == "average") {
     importance_result <- score_result |>
       group_by(location, horizon, target_end_date) |>
@@ -230,12 +231,14 @@ model_importance <- function(forecast_data,
         ~ coalesce(., mean(., na.rm = TRUE))
       )) |>
       group_by(model_id) |>
-      summarise(mean_importance = mean(importance), .groups = "drop")
+      summarise(mean_importance = mean(importance), .groups = "drop") |>
+      arrange(desc(mean_importance))
   } else {
     importance_result <- score_result |>
       filter(!is.na(importance)) |>
       group_by(model_id) |>
-      summarise(mean_importance = mean(importance), .groups = "drop")
+      summarise(mean_importance = mean(importance), .groups = "drop") |>
+      arrange(desc(mean_importance))
   }
 
   return(importance_result)

--- a/R/score_untrained.R
+++ b/R/score_untrained.R
@@ -88,7 +88,7 @@ score_untrained <- function(single_task_data, oracle_output_data, model_id_list,
     subsets <- lapply(1:n, function(x) combn(n, x, simplify = FALSE)) |>
       unlist(recursive = FALSE)
     # data frame of all possible ensemble forecasts
-    dat_all_ens <- purrr::map_dfr(
+    dat_all_ens <- furrr::future_map_dfr(
       subsets,
       function(subset) {
         get_modelsubset <- models[subset]

--- a/man/model_importance.Rd
+++ b/man/model_importance.Rd
@@ -124,7 +124,6 @@ To enable parallel execution, please set a parallel backend, e.g., via
 }
 \examples{
 \dontrun{
-future::plan(future::multisession)
 library(dplyr)
 library(hubExamples)
 forecast_data <- hubExamples::forecast_outputs |>


### PR DESCRIPTION
This PR addresses issues #30, #34, and #35:
* Parallelization is used for building ensembles in both LOMO and LASOMO.
* `future::plan(future::multisession)` is removed in the simple example in `model_importance.R`.
  - Note that `model_importance()` uses `furrr::future_map_dfr()` internally, so the `future` package is required.
* The output of `model_importance()` is sorted to place the most important model at the top.
