### PR TITLE
Refactor helper functions

### DIFF
--- a/inst/get-testdata/exp_imp_mean_untrained_lasomo/mean-case1-no_missing-linear_pool.R
+++ b/inst/get-testdata/exp_imp_mean_untrained_lasomo/mean-case1-no_missing-linear_pool.R
@@ -4,6 +4,9 @@
 # ----------------------------------------------------------------------------
 # load the package to make its internal functions available
 devtools::load_all()
+source(system.file("get-testdata/helper-exp_imp-untrained.R",
+  package = "modelimportance"
+))
 # target data
 target_data_mean <- readRDS(
   testthat::test_path("testdata/target_mean.rds")
@@ -24,33 +27,7 @@ subsets <- lapply(1:n, function(x) combn(n, x, simplify = FALSE)) |>
 # data frame of all possible ensemble forecasts
 dat_all_ens <- purrr::map_dfr(
   subsets,
-  function(subset) {
-    get_modelsubset <- models[subset]
-    # index of the subsets list that is identical to the current subset, S
-    i <- Position(function(x) identical(x, subset), subsets)
-    # calculate the weight given to this subset when subset_wt="perm_based"
-    weight_perm <- 1 / ((n - 1) * choose(n - 1, length(get_modelsubset)))
-    # when the subset includes all indices, its weight is infinite
-    # replace it with NA (this value won't be used)
-    weight_perm <- ifelse(is.infinite(weight_perm), NA, weight_perm)
-    # calculate the weight when subset_wt="equal"
-    weight_eq <- 1
-    # reduced data including the models in the subset S
-    data_subset <- dat_mean |>
-      filter(.data$model_id %in% get_modelsubset)
-    # build an ensemble forecast using the models in the subset S
-    ensemble_forecast <- linear_pool(data_subset,
-      model_id = paste0("ensemble_", i)
-    )
-    # add index and weight to the ensemble forecast
-    ens_dat <- ensemble_forecast |>
-      mutate(
-        subset_idx = i,
-        subset_wt_perm = weight_perm,
-        subset_wt_eq = weight_eq
-      )
-    ens_dat
-  }
+  function(subset) lp_ens_untrained_lasomo(models, subset, d = dat_mean)
 )
 
 # score the ensemble forecasts
@@ -73,20 +50,7 @@ model_imp_scores <- furrr::future_map_dfr(1:n, function(j) {
   scores_by_subset <- map(cols, function(col) {
     purrr::map_dbl(
       set_incl_j_more,
-      function(k) {
-        # get elements of the subset that includes j
-        set_k <- subsets[[k]]
-        # index in 'subsets' list that include elements of set_k except for j
-        k1 <- which(sapply(subsets, setequal, set_k[set_k != j]))
-        # se_point for the ensemble forecast including jth model
-        score_incl_j <- score_ens_all$se_point[k]
-        # se_point for the ensemble forecast not including jth model
-        score_not_incl_j <- score_ens_all$se_point[k1]
-        # get the subset weight for the current subset
-        subset_weight <- score_ens_all[[col]][k1]
-        # jth model's marginal contribution multiplied by the subset weight
-        subset_weight * (-score_incl_j + score_not_incl_j)
-      }
+      function(k) wtd_marginal_cntrbt_mean(k, j, score_ens_all, subsets, col)
     )
   })
 
@@ -94,20 +58,8 @@ model_imp_scores <- furrr::future_map_dfr(1:n, function(j) {
   # accumulate the scores calculated by subsets
   score <- lapply(scores_by_subset, sum)
   # store the importance score for the jth model
-  map_dfr(cols, function(col) {
-    data.frame(
-      model_id = models[j],
-      subset_wt = col,
-      importance = score[[col]]
-    )
-  }) |>
-    # importance score for the jth model depending on the subset_wt option
-    mutate(
-      subset_wt = sub("^subset_wt_", "", subset_wt),
-      importance = ifelse(subset_wt == "perm", importance,
-        importance / (2^(n - 1) - 1)
-      )
-    )
+  out <- df_score(cols, j, models, score)
+  out
 })
 
 exp_imp_mean_case1perm <- model_imp_scores |>

--- a/inst/get-testdata/exp_imp_mean_untrained_lasomo/mean-case1-no_missing-linear_pool.R
+++ b/inst/get-testdata/exp_imp_mean_untrained_lasomo/mean-case1-no_missing-linear_pool.R
@@ -27,7 +27,9 @@ subsets <- lapply(1:n, function(x) combn(n, x, simplify = FALSE)) |>
 # data frame of all possible ensemble forecasts
 dat_all_ens <- purrr::map_dfr(
   subsets,
-  function(subset) lp_ens_untrained_lasomo(models, subset, d = dat_mean)
+  function(subset) {
+    lp_ens_untrained_lasomo(models, subset, subsets, d = dat_mean)
+  }
 )
 
 # score the ensemble forecasts

--- a/inst/get-testdata/exp_imp_mean_untrained_lasomo/mean-case2-no_missing-simple-agg_mean.R
+++ b/inst/get-testdata/exp_imp_mean_untrained_lasomo/mean-case2-no_missing-simple-agg_mean.R
@@ -28,7 +28,10 @@ subsets <- lapply(1:n, function(x) combn(n, x, simplify = FALSE)) |>
 dat_all_ens <- purrr::map_dfr(
   subsets,
   function(subset) {
-    simple_ens_untrained_lasomo(models, subset, d = dat_mean, aggfun = "mean")
+    simple_ens_untrained_lasomo(models, subset, subsets,
+      d = dat_mean,
+      aggfun = "mean"
+    )
   }
 )
 

--- a/inst/get-testdata/exp_imp_mean_untrained_lasomo/mean-case2-no_missing-simple-agg_mean.R
+++ b/inst/get-testdata/exp_imp_mean_untrained_lasomo/mean-case2-no_missing-simple-agg_mean.R
@@ -4,6 +4,9 @@
 # ----------------------------------------------------------------------------
 # load the package to make its internal functions available
 devtools::load_all()
+source(system.file("get-testdata/helper-exp_imp-untrained.R",
+  package = "modelimportance"
+))
 # target data
 target_data_mean <- readRDS(
   testthat::test_path("testdata/target_mean.rds")
@@ -25,32 +28,7 @@ subsets <- lapply(1:n, function(x) combn(n, x, simplify = FALSE)) |>
 dat_all_ens <- purrr::map_dfr(
   subsets,
   function(subset) {
-    get_modelsubset <- models[subset]
-    # index of the subsets list that is identical to the current subset, S
-    i <- Position(function(x) identical(x, subset), subsets)
-    # calculate the weight given to this subset when subset_wt="perm_based"
-    weight_perm <- 1 / ((n - 1) * choose(n - 1, length(get_modelsubset)))
-    # when the subset includes all indices, its weight is infinite
-    # replace it with NA (this value won't be used)
-    weight_perm <- ifelse(is.infinite(weight_perm), NA, weight_perm)
-    # calculate the weight when subset_wt="equal"
-    weight_eq <- 1
-    # reduced data including the models in the subset S
-    data_subset <- dat_mean |>
-      filter(.data$model_id %in% get_modelsubset)
-    # build an ensemble forecast using the models in the subset S
-    ensemble_forecast <- simple_ensemble(data_subset,
-      model_id = paste0("ensemble_", i),
-      agg_fun = "mean"
-    )
-    # add index and weight to the ensemble forecast
-    ens_dat <- ensemble_forecast |>
-      mutate(
-        subset_idx = i,
-        subset_wt_perm = weight_perm,
-        subset_wt_eq = weight_eq
-      )
-    ens_dat
+    simple_ens_untrained_lasomo(models, subset, d = dat_mean, aggfun = "mean")
   }
 )
 
@@ -74,20 +52,7 @@ model_imp_scores <- furrr::future_map_dfr(1:n, function(j) {
   scores_by_subset <- map(cols, function(col) {
     purrr::map_dbl(
       set_incl_j_more,
-      function(k) {
-        # get elements of the subset that includes j
-        set_k <- subsets[[k]]
-        # index in 'subsets' list that include elements of set_k except for j
-        k1 <- which(sapply(subsets, setequal, set_k[set_k != j]))
-        # se_point for the ensemble forecast including jth model
-        score_incl_j <- score_ens_all$se_point[k]
-        # se_point for the ensemble forecast not including jth model
-        score_not_incl_j <- score_ens_all$se_point[k1]
-        # get the subset weight for the current subset
-        subset_weight <- score_ens_all[[col]][k1]
-        # jth model's marginal contribution multiplied by the subset weight
-        subset_weight * (-score_incl_j + score_not_incl_j)
-      }
+      function(k) wtd_marginal_cntrbt_mean(k, j, score_ens_all, subsets, col)
     )
   })
 
@@ -95,20 +60,8 @@ model_imp_scores <- furrr::future_map_dfr(1:n, function(j) {
   # accumulate the scores calculated by subsets
   score <- lapply(scores_by_subset, sum)
   # store the importance score for the jth model
-  map_dfr(cols, function(col) {
-    data.frame(
-      model_id = models[j],
-      subset_wt = col,
-      importance = score[[col]]
-    )
-  }) |>
-    # importance score for the jth model depending on the subset_wt option
-    mutate(
-      subset_wt = sub("^subset_wt_", "", subset_wt),
-      importance = ifelse(subset_wt == "perm", importance,
-        importance / (2^(n - 1) - 1)
-      )
-    )
+  out <- df_score(cols, j, models, score)
+  out
 })
 
 exp_imp_mean_case2perm <- model_imp_scores |>

--- a/inst/get-testdata/exp_imp_mean_untrained_lasomo/mean-case3-no_missing-simple-agg_median.R
+++ b/inst/get-testdata/exp_imp_mean_untrained_lasomo/mean-case3-no_missing-simple-agg_median.R
@@ -28,7 +28,9 @@ subsets <- lapply(1:n, function(x) combn(n, x, simplify = FALSE)) |>
 dat_all_ens <- purrr::map_dfr(
   subsets,
   function(subset) {
-    simple_ens_untrained_lasomo(models, subset, d = dat_mean, aggfun = "median")
+    simple_ens_untrained_lasomo(models, subset, subsets,
+      d = dat_mean, aggfun = "median"
+    )
   }
 )
 

--- a/inst/get-testdata/exp_imp_mean_untrained_lasomo/mean-case4-missing-simple-agg_mean.R
+++ b/inst/get-testdata/exp_imp_mean_untrained_lasomo/mean-case4-missing-simple-agg_mean.R
@@ -4,6 +4,9 @@
 # ----------------------------------------------------------------------------
 # load the package to make its internal functions available
 devtools::load_all()
+source(system.file("get-testdata/helper-exp_imp-untrained.R",
+  package = "modelimportance"
+))
 # target data
 target_data_mean <- readRDS(
   testthat::test_path("testdata/target_mean.rds")
@@ -28,32 +31,10 @@ subsets <- lapply(1:n, function(x) combn(n, x, simplify = FALSE)) |>
 dat_all_ens <- purrr::map_dfr(
   subsets,
   function(subset) {
-    get_modelsubset <- models[subset]
-    # index of the subsets list that is identical to the current subset, S
-    i <- Position(function(x) identical(x, subset), subsets)
-    # calculate the weight given to this subset when subset_wt="perm_based"
-    weight_perm <- 1 / ((n - 1) * choose(n - 1, length(get_modelsubset)))
-    # when the subset includes all indices, its weight is infinite
-    # replace it with NA (this value won't be used)
-    weight_perm <- ifelse(is.infinite(weight_perm), NA, weight_perm)
-    # calculate the weight when subset_wt="equal"
-    weight_eq <- 1
-    # reduced data including the models in the subset S
-    data_subset <- sub_dat_mean |>
-      filter(.data$model_id %in% get_modelsubset)
-    # build an ensemble forecast using the models in the subset S
-    ensemble_forecast <- simple_ensemble(data_subset,
-      model_id = paste0("ensemble_", i),
-      agg_fun = "mean"
+    simple_ens_untrained_lasomo(models, subset,
+      d = sub_dat_mean,
+      aggfun = "mean"
     )
-    # add index and weight to the ensemble forecast
-    ens_dat <- ensemble_forecast |>
-      mutate(
-        subset_idx = i,
-        subset_wt_perm = weight_perm,
-        subset_wt_eq = weight_eq
-      )
-    ens_dat
   }
 )
 
@@ -77,20 +58,7 @@ model_imp_scores <- furrr::future_map_dfr(1:n, function(j) {
   scores_by_subset <- map(cols, function(col) {
     purrr::map_dbl(
       set_incl_j_more,
-      function(k) {
-        # get elements of the subset that includes j
-        set_k <- subsets[[k]]
-        # index in 'subsets' list that include elements of set_k except for j
-        k1 <- which(sapply(subsets, setequal, set_k[set_k != j]))
-        # se_point for the ensemble forecast including jth model
-        score_incl_j <- score_ens_all$se_point[k]
-        # se_point for the ensemble forecast not including jth model
-        score_not_incl_j <- score_ens_all$se_point[k1]
-        # get the subset weight for the current subset
-        subset_weight <- score_ens_all[[col]][k1]
-        # jth model's marginal contribution multiplied by the subset weight
-        subset_weight * (-score_incl_j + score_not_incl_j)
-      }
+      function(k) wtd_marginal_cntrbt_mean(k, j, score_ens_all, subsets, col)
     )
   })
 
@@ -98,20 +66,8 @@ model_imp_scores <- furrr::future_map_dfr(1:n, function(j) {
   # accumulate the scores calculated by subsets
   score <- lapply(scores_by_subset, sum)
   # store the importance score for the jth model
-  map_dfr(cols, function(col) {
-    data.frame(
-      model_id = models[j],
-      subset_wt = col,
-      importance = score[[col]]
-    )
-  }) |>
-    # importance score for the jth model depending on the subset_wt option
-    mutate(
-      subset_wt = sub("^subset_wt_", "", subset_wt),
-      importance = ifelse(subset_wt == "perm", importance,
-        importance / (2^(n - 1) - 1)
-      )
-    )
+  out <- df_score(cols, j, models, score)
+  out
 })
 
 exp_imp_mean_case4perm <- model_imp_scores |>

--- a/inst/get-testdata/exp_imp_mean_untrained_lasomo/mean-case4-missing-simple-agg_mean.R
+++ b/inst/get-testdata/exp_imp_mean_untrained_lasomo/mean-case4-missing-simple-agg_mean.R
@@ -31,7 +31,7 @@ subsets <- lapply(1:n, function(x) combn(n, x, simplify = FALSE)) |>
 dat_all_ens <- purrr::map_dfr(
   subsets,
   function(subset) {
-    simple_ens_untrained_lasomo(models, subset,
+    simple_ens_untrained_lasomo(models, subset, subsets,
       d = sub_dat_mean,
       aggfun = "mean"
     )

--- a/inst/get-testdata/exp_imp_median_untrained_lasomo/median-case1-no_missing-simple-agg_mean.R
+++ b/inst/get-testdata/exp_imp_median_untrained_lasomo/median-case1-no_missing-simple-agg_mean.R
@@ -28,7 +28,9 @@ subsets <- lapply(1:n, function(x) combn(n, x, simplify = FALSE)) |>
 dat_all_ens <- purrr::map_dfr(
   subsets,
   function(subset) {
-    simple_ens_untrained_lasomo(models, subset, d = dat_median, aggfun = "mean")
+    simple_ens_untrained_lasomo(models, subset, subsets,
+      d = dat_median, aggfun = "mean"
+    )
   }
 )
 

--- a/inst/get-testdata/exp_imp_median_untrained_lasomo/median-case1-no_missing-simple-agg_mean.R
+++ b/inst/get-testdata/exp_imp_median_untrained_lasomo/median-case1-no_missing-simple-agg_mean.R
@@ -60,20 +60,8 @@ model_imp_scores <- furrr::future_map_dfr(1:n, function(j) {
   # accumulate the scores calculated by subsets
   score <- lapply(scores_by_subset, sum)
   # store the importance score for the jth model
-  map_dfr(cols, function(col) {
-    data.frame(
-      model_id = models[j],
-      subset_wt = col,
-      importance = score[[col]]
-    )
-  }) |>
-    # importance score for the jth model depending on the subset_wt option
-    mutate(
-      subset_wt = sub("^subset_wt_", "", subset_wt),
-      importance = ifelse(subset_wt == "perm", importance,
-        importance / (2^(n - 1) - 1)
-      )
-    )
+  out <- df_score(cols, j, models, score)
+  out
 })
 
 exp_imp_median_case1perm <- model_imp_scores |>

--- a/inst/get-testdata/exp_imp_median_untrained_lasomo/median-case1-no_missing-simple-agg_mean.R
+++ b/inst/get-testdata/exp_imp_median_untrained_lasomo/median-case1-no_missing-simple-agg_mean.R
@@ -4,6 +4,9 @@
 # ----------------------------------------------------------------------------
 # load the package to make its internal functions available
 devtools::load_all()
+source(system.file("get-testdata/helper-exp_imp-untrained.R",
+  package = "modelimportance"
+))
 # target data
 target_data_median <- readRDS(
   testthat::test_path("testdata/target_median.rds")
@@ -25,32 +28,7 @@ subsets <- lapply(1:n, function(x) combn(n, x, simplify = FALSE)) |>
 dat_all_ens <- purrr::map_dfr(
   subsets,
   function(subset) {
-    get_modelsubset <- models[subset]
-    # index of the subsets list that is identical to the current subset, S
-    i <- Position(function(x) identical(x, subset), subsets)
-    # calculate the weight given to this subset when subset_wt="perm_based"
-    weight_perm <- 1 / ((n - 1) * choose(n - 1, length(get_modelsubset)))
-    # when the subset includes all indices, its weight is infinite
-    # replace it with NA (this value won't be used)
-    weight_perm <- ifelse(is.infinite(weight_perm), NA, weight_perm)
-    # calculate the weight when subset_wt="equal"
-    weight_eq <- 1
-    # reduced data including the models in the subset S
-    data_subset <- dat_median |>
-      filter(.data$model_id %in% get_modelsubset)
-    # build an ensemble forecast using the models in the subset S
-    ensemble_forecast <- simple_ensemble(data_subset,
-      model_id = paste0("ensemble_", i),
-      agg_fun = "mean"
-    )
-    # add index and weight to the ensemble forecast
-    ens_dat <- ensemble_forecast |>
-      mutate(
-        subset_idx = i,
-        subset_wt_perm = weight_perm,
-        subset_wt_eq = weight_eq
-      )
-    ens_dat
+    simple_ens_untrained_lasomo(models, subset, d = dat_median, aggfun = "mean")
   }
 )
 
@@ -74,20 +52,7 @@ model_imp_scores <- furrr::future_map_dfr(1:n, function(j) {
   scores_by_subset <- map(cols, function(col) {
     purrr::map_dbl(
       set_incl_j_more,
-      function(k) {
-        # get elements of the subset that includes j
-        set_k <- subsets[[k]]
-        # index in 'subsets' list that include elements of set_k except for j
-        k1 <- which(sapply(subsets, setequal, set_k[set_k != j]))
-        # ae_point for the ensemble forecast including jth model
-        score_incl_j <- score_ens_all$ae_point[k]
-        # ae_point for the ensemble forecast not including jth model
-        score_not_incl_j <- score_ens_all$ae_point[k1]
-        # get the subset weight for the current subset
-        subset_weight <- score_ens_all[[col]][k1]
-        # jth model's marginal contribution multiplied by the subset weight
-        subset_weight * (-score_incl_j + score_not_incl_j)
-      }
+      function(k) wtd_marginal_cntrbt_median(k, j, score_ens_all, subsets, col)
     )
   })
 

--- a/inst/get-testdata/exp_imp_median_untrained_lasomo/median-case2-no_missing-simple-agg_median.R
+++ b/inst/get-testdata/exp_imp_median_untrained_lasomo/median-case2-no_missing-simple-agg_median.R
@@ -28,7 +28,7 @@ subsets <- lapply(1:n, function(x) combn(n, x, simplify = FALSE)) |>
 dat_all_ens <- purrr::map_dfr(
   subsets,
   function(subset) {
-    simple_ens_untrained_lasomo(models, subset,
+    simple_ens_untrained_lasomo(models, subset, subsets,
       d = dat_median,
       aggfun = "median"
     )

--- a/inst/get-testdata/exp_imp_median_untrained_lasomo/median-case2-no_missing-simple-agg_median.R
+++ b/inst/get-testdata/exp_imp_median_untrained_lasomo/median-case2-no_missing-simple-agg_median.R
@@ -63,20 +63,8 @@ model_imp_scores <- furrr::future_map_dfr(1:n, function(j) {
   # accumulate the scores calculated by subsets
   score <- lapply(scores_by_subset, sum)
   # store the importance score for the jth model
-  map_dfr(cols, function(col) {
-    data.frame(
-      model_id = models[j],
-      subset_wt = col,
-      importance = score[[col]]
-    )
-  }) |>
-    # importance score for the jth model depending on the subset_wt option
-    mutate(
-      subset_wt = sub("^subset_wt_", "", subset_wt),
-      importance = ifelse(subset_wt == "perm", importance,
-        importance / (2^(n - 1) - 1)
-      )
-    )
+  out <- df_score(cols, j, models, score)
+  out
 })
 
 exp_imp_median_case2perm <- model_imp_scores |>

--- a/inst/get-testdata/exp_imp_median_untrained_lasomo/median-case2-no_missing-simple-agg_median.R
+++ b/inst/get-testdata/exp_imp_median_untrained_lasomo/median-case2-no_missing-simple-agg_median.R
@@ -4,6 +4,9 @@
 # ----------------------------------------------------------------------------
 # load the package to make its internal functions available
 devtools::load_all()
+source(system.file("get-testdata/helper-exp_imp-untrained.R",
+  package = "modelimportance"
+))
 # target data
 target_data_median <- readRDS(
   testthat::test_path("testdata/target_median.rds")
@@ -25,32 +28,10 @@ subsets <- lapply(1:n, function(x) combn(n, x, simplify = FALSE)) |>
 dat_all_ens <- purrr::map_dfr(
   subsets,
   function(subset) {
-    get_modelsubset <- models[subset]
-    # index of the subsets list that is identical to the current subset, S
-    i <- Position(function(x) identical(x, subset), subsets)
-    # calculate the weight given to this subset when subset_wt="perm_based"
-    weight_perm <- 1 / ((n - 1) * choose(n - 1, length(get_modelsubset)))
-    # when the subset includes all indices, its weight is infinite
-    # replace it with NA (this value won't be used)
-    weight_perm <- ifelse(is.infinite(weight_perm), NA, weight_perm)
-    # calculate the weight when subset_wt="equal"
-    weight_eq <- 1
-    # reduced data including the models in the subset S
-    data_subset <- dat_median |>
-      filter(.data$model_id %in% get_modelsubset)
-    # build an ensemble forecast using the models in the subset S
-    ensemble_forecast <- simple_ensemble(data_subset,
-      model_id = paste0("ensemble_", i),
-      agg_fun = "median"
+    simple_ens_untrained_lasomo(models, subset,
+      d = dat_median,
+      aggfun = "median"
     )
-    # add index and weight to the ensemble forecast
-    ens_dat <- ensemble_forecast |>
-      mutate(
-        subset_idx = i,
-        subset_wt_perm = weight_perm,
-        subset_wt_eq = weight_eq
-      )
-    ens_dat
   }
 )
 
@@ -74,20 +55,7 @@ model_imp_scores <- furrr::future_map_dfr(1:n, function(j) {
   scores_by_subset <- map(cols, function(col) {
     purrr::map_dbl(
       set_incl_j_more,
-      function(k) {
-        # get elements of the subset that includes j
-        set_k <- subsets[[k]]
-        # index in 'subsets' list that include elements of set_k except for j
-        k1 <- which(sapply(subsets, setequal, set_k[set_k != j]))
-        # ae_point for the ensemble forecast including jth model
-        score_incl_j <- score_ens_all$ae_point[k]
-        # ae_point for the ensemble forecast not including jth model
-        score_not_incl_j <- score_ens_all$ae_point[k1]
-        # get the subset weight for the current subset
-        subset_weight <- score_ens_all[[col]][k1]
-        # jth model's marginal contribution multiplied by the subset weight
-        subset_weight * (-score_incl_j + score_not_incl_j)
-      }
+      function(k) wtd_marginal_cntrbt_median(k, j, score_ens_all, subsets, col)
     )
   })
 

--- a/inst/get-testdata/exp_imp_median_untrained_lasomo/median-case3-missing-simple-agg_mean.R
+++ b/inst/get-testdata/exp_imp_median_untrained_lasomo/median-case3-missing-simple-agg_mean.R
@@ -4,6 +4,9 @@
 # ----------------------------------------------------------------------------
 # load the package to make its internal functions available
 devtools::load_all()
+source(system.file("get-testdata/helper-exp_imp-untrained.R",
+  package = "modelimportance"
+))
 # target data
 target_data_median <- readRDS(
   testthat::test_path("testdata/target_median.rds")
@@ -29,32 +32,10 @@ subsets <- lapply(1:n, function(x) combn(n, x, simplify = FALSE)) |>
 dat_all_ens <- purrr::map_dfr(
   subsets,
   function(subset) {
-    get_modelsubset <- models[subset]
-    # index of the subsets list that is identical to the current subset, S
-    i <- Position(function(x) identical(x, subset), subsets)
-    # calculate the weight given to this subset when subset_wt="perm_based"
-    weight_perm <- 1 / ((n - 1) * choose(n - 1, length(get_modelsubset)))
-    # when the subset includes all indices, its weight is infinite
-    # replace it with NA (this value won't be used)
-    weight_perm <- ifelse(is.infinite(weight_perm), NA, weight_perm)
-    # calculate the weight when subset_wt="equal"
-    weight_eq <- 1
-    # reduced data including the models in the subset S
-    data_subset <- sub_dat_median |>
-      filter(.data$model_id %in% get_modelsubset)
-    # build an ensemble forecast using the models in the subset S
-    ensemble_forecast <- simple_ensemble(data_subset,
-      model_id = paste0("ensemble_", i),
-      agg_fun = "mean"
+    simple_ens_untrained_lasomo(models, subset,
+      d = sub_dat_median,
+      aggfun = "mean"
     )
-    # add index and weight to the ensemble forecast
-    ens_dat <- ensemble_forecast |>
-      mutate(
-        subset_idx = i,
-        subset_wt_perm = weight_perm,
-        subset_wt_eq = weight_eq
-      )
-    ens_dat
   }
 )
 
@@ -78,20 +59,7 @@ model_imp_scores <- furrr::future_map_dfr(1:n, function(j) {
   scores_by_subset <- map(cols, function(col) {
     purrr::map_dbl(
       set_incl_j_more,
-      function(k) {
-        # get elements of the subset that includes j
-        set_k <- subsets[[k]]
-        # index in 'subsets' list that include elements of set_k except for j
-        k1 <- which(sapply(subsets, setequal, set_k[set_k != j]))
-        # ae_point for the ensemble forecast including jth model
-        score_incl_j <- score_ens_all$ae_point[k]
-        # ae_point for the ensemble forecast not including jth model
-        score_not_incl_j <- score_ens_all$ae_point[k1]
-        # get the subset weight for the current subset
-        subset_weight <- score_ens_all[[col]][k1]
-        # jth model's marginal contribution multiplied by the subset weight
-        subset_weight * (-score_incl_j + score_not_incl_j)
-      }
+      function(k) wtd_marginal_cntrbt_median(k, j, score_ens_all, subsets, col)
     )
   })
 

--- a/inst/get-testdata/exp_imp_median_untrained_lasomo/median-case3-missing-simple-agg_mean.R
+++ b/inst/get-testdata/exp_imp_median_untrained_lasomo/median-case3-missing-simple-agg_mean.R
@@ -67,20 +67,8 @@ model_imp_scores <- furrr::future_map_dfr(1:n, function(j) {
   # accumulate the scores calculated by subsets
   score <- lapply(scores_by_subset, sum)
   # store the importance score for the jth model
-  map_dfr(cols, function(col) {
-    data.frame(
-      model_id = models[j],
-      subset_wt = col,
-      importance = score[[col]]
-    )
-  }) |>
-    # importance score for the jth model depending on the subset_wt option
-    mutate(
-      subset_wt = sub("^subset_wt_", "", subset_wt),
-      importance = ifelse(subset_wt == "perm", importance,
-        importance / (2^(n - 1) - 1)
-      )
-    )
+  out <- df_score(cols, j, models, score)
+  out
 })
 
 exp_imp_median_case3perm <- model_imp_scores |>

--- a/inst/get-testdata/exp_imp_median_untrained_lasomo/median-case3-missing-simple-agg_mean.R
+++ b/inst/get-testdata/exp_imp_median_untrained_lasomo/median-case3-missing-simple-agg_mean.R
@@ -32,7 +32,7 @@ subsets <- lapply(1:n, function(x) combn(n, x, simplify = FALSE)) |>
 dat_all_ens <- purrr::map_dfr(
   subsets,
   function(subset) {
-    simple_ens_untrained_lasomo(models, subset,
+    simple_ens_untrained_lasomo(models, subset, subsets,
       d = sub_dat_median,
       aggfun = "mean"
     )

--- a/inst/get-testdata/exp_imp_pmf_untrained_lasomo/pmf-case1-no_missing-linear_pool.R
+++ b/inst/get-testdata/exp_imp_pmf_untrained_lasomo/pmf-case1-no_missing-linear_pool.R
@@ -63,20 +63,8 @@ model_imp_scores <- furrr::future_map_dfr(1:n, function(j) {
   # accumulate the scores calculated by subsets
   score <- lapply(scores_by_subset, sum)
   # store the importance score for the jth model
-  map_dfr(cols, function(col) {
-    data.frame(
-      model_id = models[j],
-      subset_wt = col,
-      importance = score[[col]]
-    )
-  }) |>
-    # importance score for the jth model depending on the subset_wt option
-    mutate(
-      subset_wt = sub("^subset_wt_", "", subset_wt),
-      importance = ifelse(subset_wt == "perm", importance,
-        importance / (2^(n - 1) - 1)
-      )
-    )
+  out <- df_score(cols, j, models, score)
+  out
 })
 
 exp_imp_pmf_case1perm <- model_imp_scores |>

--- a/inst/get-testdata/exp_imp_pmf_untrained_lasomo/pmf-case1-no_missing-linear_pool.R
+++ b/inst/get-testdata/exp_imp_pmf_untrained_lasomo/pmf-case1-no_missing-linear_pool.R
@@ -27,7 +27,9 @@ subsets <- lapply(1:n, function(x) combn(n, x, simplify = FALSE)) |>
 # data frame of all possible ensemble forecasts
 dat_all_ens <- purrr::map_dfr(
   subsets,
-  function(subset) lp_ens_untrained_lasomo(models, subset, d = dat_pmf)
+  function(subset) {
+    lp_ens_untrained_lasomo(models, subset, subsets, d = dat_pmf)
+  }
 )
 
 # score the ensemble forecasts

--- a/inst/get-testdata/exp_imp_pmf_untrained_lasomo/pmf-case1-no_missing-linear_pool.R
+++ b/inst/get-testdata/exp_imp_pmf_untrained_lasomo/pmf-case1-no_missing-linear_pool.R
@@ -4,6 +4,9 @@
 # ----------------------------------------------------------------------------
 # load the package to make its internal functions available
 devtools::load_all()
+source(system.file("get-testdata/helper-exp_imp-untrained.R",
+  package = "modelimportance"
+))
 # target data
 target_data_pmf <- readRDS(
   testthat::test_path("testdata/target_pmf.rds")
@@ -24,33 +27,7 @@ subsets <- lapply(1:n, function(x) combn(n, x, simplify = FALSE)) |>
 # data frame of all possible ensemble forecasts
 dat_all_ens <- purrr::map_dfr(
   subsets,
-  function(subset) {
-    get_modelsubset <- models[subset]
-    # index of the subsets list that is identical to the current subset, S
-    i <- Position(function(x) identical(x, subset), subsets)
-    # calculate the weight given to this subset when subset_wt="perm_based"
-    weight_perm <- 1 / ((n - 1) * choose(n - 1, length(get_modelsubset)))
-    # when the subset includes all indices, its weight is infinite
-    # replace it with NA (this value won't be used)
-    weight_perm <- ifelse(is.infinite(weight_perm), NA, weight_perm)
-    # calculate the weight when subset_wt="equal"
-    weight_eq <- 1
-    # reduced data including the models in the subset S
-    data_subset <- dat_pmf |>
-      filter(.data$model_id %in% get_modelsubset)
-    # build an ensemble forecast using the models in the subset S
-    ensemble_forecast <- linear_pool(data_subset,
-      model_id = paste0("ensemble_", i)
-    )
-    # add index and weight to the ensemble forecast
-    ens_dat <- ensemble_forecast |>
-      mutate(
-        subset_idx = i,
-        subset_wt_perm = weight_perm,
-        subset_wt_eq = weight_eq
-      )
-    ens_dat
-  }
+  function(subset) lp_ens_untrained_lasomo(models, subset, d = dat_pmf)
 )
 
 # score the ensemble forecasts
@@ -78,20 +55,7 @@ model_imp_scores <- furrr::future_map_dfr(1:n, function(j) {
   scores_by_subset <- map(cols, function(col) {
     purrr::map_dbl(
       set_incl_j_more,
-      function(k) {
-        # get elements of the subset that includes j
-        set_k <- subsets[[k]]
-        # index in 'subsets' list that include elements of set_k except for j
-        k1 <- which(sapply(subsets, setequal, set_k[set_k != j]))
-        # log_score for the ensemble forecast including jth model
-        score_incl_j <- score_ens_all$log_score[k]
-        # log_score for the ensemble forecast not including jth model
-        score_not_incl_j <- score_ens_all$log_score[k1]
-        # get the subset weight for the current subset
-        subset_weight <- score_ens_all[[col]][k1]
-        # jth model's marginal contribution multiplied by the subset weight
-        subset_weight * (-score_incl_j + score_not_incl_j)
-      }
+      function(k) wtd_marginal_cntrbt_pmf(k, j, score_ens_all, subsets, col)
     )
   })
 

--- a/inst/get-testdata/exp_imp_pmf_untrained_lasomo/pmf-case2-no_missing-simple-agg_mean.R
+++ b/inst/get-testdata/exp_imp_pmf_untrained_lasomo/pmf-case2-no_missing-simple-agg_mean.R
@@ -65,20 +65,8 @@ model_imp_scores <- furrr::future_map_dfr(1:n, function(j) {
   # accumulate the scores calculated by subsets
   score <- lapply(scores_by_subset, sum)
   # store the importance score for the jth model
-  map_dfr(cols, function(col) {
-    data.frame(
-      model_id = models[j],
-      subset_wt = col,
-      importance = score[[col]]
-    )
-  }) |>
-    # importance score for the jth model depending on the subset_wt option
-    mutate(
-      subset_wt = sub("^subset_wt_", "", subset_wt),
-      importance = ifelse(subset_wt == "perm", importance,
-        importance / (2^(n - 1) - 1)
-      )
-    )
+  out <- df_score(cols, j, models, score)
+  out
 })
 
 exp_imp_pmf_case2perm <- model_imp_scores |>

--- a/inst/get-testdata/exp_imp_pmf_untrained_lasomo/pmf-case2-no_missing-simple-agg_mean.R
+++ b/inst/get-testdata/exp_imp_pmf_untrained_lasomo/pmf-case2-no_missing-simple-agg_mean.R
@@ -4,6 +4,9 @@
 # ----------------------------------------------------------------------------
 # load the package to make its internal functions available
 devtools::load_all()
+source(system.file("get-testdata/helper-exp_imp-untrained.R",
+  package = "modelimportance"
+))
 # target data
 target_data_pmf <- readRDS(
   testthat::test_path("testdata/target_pmf.rds")
@@ -25,32 +28,7 @@ subsets <- lapply(1:n, function(x) combn(n, x, simplify = FALSE)) |>
 dat_all_ens <- purrr::map_dfr(
   subsets,
   function(subset) {
-    get_modelsubset <- models[subset]
-    # index of the subsets list that is identical to the current subset, S
-    i <- Position(function(x) identical(x, subset), subsets)
-    # calculate the weight given to this subset when subset_wt="perm_based"
-    weight_perm <- 1 / ((n - 1) * choose(n - 1, length(get_modelsubset)))
-    # when the subset includes all indices, its weight is infinite
-    # replace it with NA (this value won't be used)
-    weight_perm <- ifelse(is.infinite(weight_perm), NA, weight_perm)
-    # calculate the weight when subset_wt="equal"
-    weight_eq <- 1
-    # reduced data including the models in the subset S
-    data_subset <- dat_pmf |>
-      filter(.data$model_id %in% get_modelsubset)
-    # build an ensemble forecast using the models in the subset S
-    ensemble_forecast <- simple_ensemble(data_subset,
-      model_id = paste0("ensemble_", i),
-      agg_fun = "mean"
-    )
-    # add index and weight to the ensemble forecast
-    ens_dat <- ensemble_forecast |>
-      mutate(
-        subset_idx = i,
-        subset_wt_perm = weight_perm,
-        subset_wt_eq = weight_eq
-      )
-    ens_dat
+    simple_ens_untrained_lasomo(models, subset, d = dat_pmf, aggfun = "mean")
   }
 )
 
@@ -79,20 +57,7 @@ model_imp_scores <- furrr::future_map_dfr(1:n, function(j) {
   scores_by_subset <- map(cols, function(col) {
     purrr::map_dbl(
       set_incl_j_more,
-      function(k) {
-        # get elements of the subset that includes j
-        set_k <- subsets[[k]]
-        # index in 'subsets' list that include elements of set_k except for j
-        k1 <- which(sapply(subsets, setequal, set_k[set_k != j]))
-        # log_score for the ensemble forecast including jth model
-        score_incl_j <- score_ens_all$log_score[k]
-        # log_score for the ensemble forecast not including jth model
-        score_not_incl_j <- score_ens_all$log_score[k1]
-        # get the subset weight for the current subset
-        subset_weight <- score_ens_all[[col]][k1]
-        # jth model's marginal contribution multiplied by the subset weight
-        subset_weight * (-score_incl_j + score_not_incl_j)
-      }
+      function(k) wtd_marginal_cntrbt_pmf(k, j, score_ens_all, subsets, col)
     )
   })
 

--- a/inst/get-testdata/exp_imp_pmf_untrained_lasomo/pmf-case2-no_missing-simple-agg_mean.R
+++ b/inst/get-testdata/exp_imp_pmf_untrained_lasomo/pmf-case2-no_missing-simple-agg_mean.R
@@ -28,7 +28,9 @@ subsets <- lapply(1:n, function(x) combn(n, x, simplify = FALSE)) |>
 dat_all_ens <- purrr::map_dfr(
   subsets,
   function(subset) {
-    simple_ens_untrained_lasomo(models, subset, d = dat_pmf, aggfun = "mean")
+    simple_ens_untrained_lasomo(models, subset, subsets,
+      d = dat_pmf, aggfun = "mean"
+    )
   }
 )
 

--- a/inst/get-testdata/exp_imp_pmf_untrained_lasomo/pmf-case3-no_missing-simple-agg_median.R
+++ b/inst/get-testdata/exp_imp_pmf_untrained_lasomo/pmf-case3-no_missing-simple-agg_median.R
@@ -65,20 +65,8 @@ model_imp_scores <- furrr::future_map_dfr(1:n, function(j) {
   # accumulate the scores calculated by subsets
   score <- lapply(scores_by_subset, sum)
   # store the importance score for the jth model
-  map_dfr(cols, function(col) {
-    data.frame(
-      model_id = models[j],
-      subset_wt = col,
-      importance = score[[col]]
-    )
-  }) |>
-    # importance score for the jth model depending on the subset_wt option
-    mutate(
-      subset_wt = sub("^subset_wt_", "", subset_wt),
-      importance = ifelse(subset_wt == "perm", importance,
-        importance / (2^(n - 1) - 1)
-      )
-    )
+  out <- df_score(cols, j, models, score)
+  out
 })
 
 exp_imp_pmf_case3perm <- model_imp_scores |>

--- a/inst/get-testdata/exp_imp_pmf_untrained_lasomo/pmf-case3-no_missing-simple-agg_median.R
+++ b/inst/get-testdata/exp_imp_pmf_untrained_lasomo/pmf-case3-no_missing-simple-agg_median.R
@@ -28,7 +28,9 @@ subsets <- lapply(1:n, function(x) combn(n, x, simplify = FALSE)) |>
 dat_all_ens <- purrr::map_dfr(
   subsets,
   function(subset) {
-    simple_ens_untrained_lasomo(models, subset, d = dat_pmf, aggfun = "median")
+    simple_ens_untrained_lasomo(models, subset, subsets,
+      d = dat_pmf, aggfun = "median"
+    )
   }
 )
 

--- a/inst/get-testdata/exp_imp_pmf_untrained_lasomo/pmf-case3-no_missing-simple-agg_median.R
+++ b/inst/get-testdata/exp_imp_pmf_untrained_lasomo/pmf-case3-no_missing-simple-agg_median.R
@@ -4,6 +4,9 @@
 # ----------------------------------------------------------------------------
 # load the package to make its internal functions available
 devtools::load_all()
+source(system.file("get-testdata/helper-exp_imp-untrained.R",
+  package = "modelimportance"
+))
 # target data
 target_data_pmf <- readRDS(
   testthat::test_path("testdata/target_pmf.rds")
@@ -25,32 +28,7 @@ subsets <- lapply(1:n, function(x) combn(n, x, simplify = FALSE)) |>
 dat_all_ens <- purrr::map_dfr(
   subsets,
   function(subset) {
-    get_modelsubset <- models[subset]
-    # index of the subsets list that is identical to the current subset, S
-    i <- Position(function(x) identical(x, subset), subsets)
-    # calculate the weight given to this subset when subset_wt="perm_based"
-    weight_perm <- 1 / ((n - 1) * choose(n - 1, length(get_modelsubset)))
-    # when the subset includes all indices, its weight is infinite
-    # replace it with NA (this value won't be used)
-    weight_perm <- ifelse(is.infinite(weight_perm), NA, weight_perm)
-    # calculate the weight when subset_wt="equal"
-    weight_eq <- 1
-    # reduced data including the models in the subset S
-    data_subset <- dat_pmf |>
-      filter(.data$model_id %in% get_modelsubset)
-    # build an ensemble forecast using the models in the subset S
-    ensemble_forecast <- simple_ensemble(data_subset,
-      model_id = paste0("ensemble_", i),
-      agg_fun = "median"
-    )
-    # add index and weight to the ensemble forecast
-    ens_dat <- ensemble_forecast |>
-      mutate(
-        subset_idx = i,
-        subset_wt_perm = weight_perm,
-        subset_wt_eq = weight_eq
-      )
-    ens_dat
+    simple_ens_untrained_lasomo(models, subset, d = dat_pmf, aggfun = "median")
   }
 )
 
@@ -79,20 +57,7 @@ model_imp_scores <- furrr::future_map_dfr(1:n, function(j) {
   scores_by_subset <- map(cols, function(col) {
     purrr::map_dbl(
       set_incl_j_more,
-      function(k) {
-        # get elements of the subset that includes j
-        set_k <- subsets[[k]]
-        # index in 'subsets' list that include elements of set_k except for j
-        k1 <- which(sapply(subsets, setequal, set_k[set_k != j]))
-        # log_score for the ensemble forecast including jth model
-        score_incl_j <- score_ens_all$log_score[k]
-        # log_score for the ensemble forecast not including jth model
-        score_not_incl_j <- score_ens_all$log_score[k1]
-        # get the subset weight for the current subset
-        subset_weight <- score_ens_all[[col]][k1]
-        # jth model's marginal contribution multiplied by the subset weight
-        subset_weight * (-score_incl_j + score_not_incl_j)
-      }
+      function(k) wtd_marginal_cntrbt_pmf(k, j, score_ens_all, subsets, col)
     )
   })
 

--- a/inst/get-testdata/exp_imp_pmf_untrained_lasomo/pmf-case4-missing-simple-agg_mean.R
+++ b/inst/get-testdata/exp_imp_pmf_untrained_lasomo/pmf-case4-missing-simple-agg_mean.R
@@ -31,7 +31,7 @@ subsets <- lapply(1:n, function(x) combn(n, x, simplify = FALSE)) |>
 dat_all_ens <- purrr::map_dfr(
   subsets,
   function(subset) {
-    simple_ens_untrained_lasomo(models, subset,
+    simple_ens_untrained_lasomo(models, subset, subsets,
       d = sub_dat_pmf,
       aggfun = "mean"
     )

--- a/inst/get-testdata/exp_imp_pmf_untrained_lasomo/pmf-case4-missing-simple-agg_mean.R
+++ b/inst/get-testdata/exp_imp_pmf_untrained_lasomo/pmf-case4-missing-simple-agg_mean.R
@@ -4,6 +4,9 @@
 # ----------------------------------------------------------------------------
 # load the package to make its internal functions available
 devtools::load_all()
+source(system.file("get-testdata/helper-exp_imp-untrained.R",
+  package = "modelimportance"
+))
 # target data
 target_data_pmf <- readRDS(
   testthat::test_path("testdata/target_pmf.rds")
@@ -28,32 +31,10 @@ subsets <- lapply(1:n, function(x) combn(n, x, simplify = FALSE)) |>
 dat_all_ens <- purrr::map_dfr(
   subsets,
   function(subset) {
-    get_modelsubset <- models[subset]
-    # index of the subsets list that is identical to the current subset, S
-    i <- Position(function(x) identical(x, subset), subsets)
-    # calculate the weight given to this subset when subset_wt="perm_based"
-    weight_perm <- 1 / ((n - 1) * choose(n - 1, length(get_modelsubset)))
-    # when the subset includes all indices, its weight is infinite
-    # replace it with NA (this value won't be used)
-    weight_perm <- ifelse(is.infinite(weight_perm), NA, weight_perm)
-    # calculate the weight when subset_wt="equal"
-    weight_eq <- 1
-    # reduced data including the models in the subset S
-    data_subset <- sub_dat_pmf |>
-      filter(.data$model_id %in% get_modelsubset)
-    # build an ensemble forecast using the models in the subset S
-    ensemble_forecast <- simple_ensemble(data_subset,
-      model_id = paste0("ensemble_", i),
-      agg_fun = "mean"
+    simple_ens_untrained_lasomo(models, subset,
+      d = sub_dat_pmf,
+      aggfun = "mean"
     )
-    # add index and weight to the ensemble forecast
-    ens_dat <- ensemble_forecast |>
-      mutate(
-        subset_idx = i,
-        subset_wt_perm = weight_perm,
-        subset_wt_eq = weight_eq
-      )
-    ens_dat
   }
 )
 
@@ -82,20 +63,7 @@ model_imp_scores <- furrr::future_map_dfr(1:n, function(j) {
   scores_by_subset <- map(cols, function(col) {
     purrr::map_dbl(
       set_incl_j_more,
-      function(k) {
-        # get elements of the subset that includes j
-        set_k <- subsets[[k]]
-        # index in 'subsets' list that include elements of set_k except for j
-        k1 <- which(sapply(subsets, setequal, set_k[set_k != j]))
-        # log_score for the ensemble forecast including jth model
-        score_incl_j <- score_ens_all$log_score[k]
-        # log_score for the ensemble forecast not including jth model
-        score_not_incl_j <- score_ens_all$log_score[k1]
-        # get the subset weight for the current subset
-        subset_weight <- score_ens_all[[col]][k1]
-        # jth model's marginal contribution multiplied by the subset weight
-        subset_weight * (-score_incl_j + score_not_incl_j)
-      }
+      function(k) wtd_marginal_cntrbt_pmf(k, j, score_ens_all, subsets, col)
     )
   })
 

--- a/inst/get-testdata/exp_imp_pmf_untrained_lasomo/pmf-case4-missing-simple-agg_mean.R
+++ b/inst/get-testdata/exp_imp_pmf_untrained_lasomo/pmf-case4-missing-simple-agg_mean.R
@@ -71,20 +71,8 @@ model_imp_scores <- furrr::future_map_dfr(1:n, function(j) {
   # accumulate the scores calculated by subsets
   score <- lapply(scores_by_subset, sum)
   # store the importance score for the jth model
-  map_dfr(cols, function(col) {
-    data.frame(
-      model_id = models[j],
-      subset_wt = col,
-      importance = score[[col]]
-    )
-  }) |>
-    # importance score for the jth model depending on the subset_wt option
-    mutate(
-      subset_wt = sub("^subset_wt_", "", subset_wt),
-      importance = ifelse(subset_wt == "perm", importance,
-        importance / (2^(n - 1) - 1)
-      )
-    )
+  out <- df_score(cols, j, models, score)
+  out
 })
 
 exp_imp_pmf_case4perm <- model_imp_scores |>

--- a/inst/get-testdata/exp_imp_qntl_untrained_lasomo/qntl-case1-no_missing-linear_pool.R
+++ b/inst/get-testdata/exp_imp_qntl_untrained_lasomo/qntl-case1-no_missing-linear_pool.R
@@ -27,7 +27,9 @@ subsets <- lapply(1:n, function(x) combn(n, x, simplify = FALSE)) |>
 # data frame of all possible ensemble forecasts
 dat_all_ens <- purrr::map_dfr(
   subsets,
-  function(subset) lp_ens_untrained_lasomo(models, subset, d = dat_qntl)
+  function(subset) {
+    lp_ens_untrained_lasomo(models, subset, subsets, d = dat_qntl)
+  }
 )
 
 # score the ensemble forecasts

--- a/inst/get-testdata/exp_imp_qntl_untrained_lasomo/qntl-case1-no_missing-linear_pool.R
+++ b/inst/get-testdata/exp_imp_qntl_untrained_lasomo/qntl-case1-no_missing-linear_pool.R
@@ -63,20 +63,8 @@ model_imp_scores <- furrr::future_map_dfr(1:n, function(j) {
   # accumulate the scores calculated by subsets
   score <- lapply(scores_by_subset, sum)
   # store the importance score for the jth model
-  map_dfr(cols, function(col) {
-    data.frame(
-      model_id = models[j],
-      subset_wt = col,
-      importance = score[[col]]
-    )
-  }) |>
-    # importance score for the jth model depending on the subset_wt option
-    mutate(
-      subset_wt = sub("^subset_wt_", "", subset_wt),
-      importance = ifelse(subset_wt == "perm", importance,
-        importance / (2^(n - 1) - 1)
-      )
-    )
+  out <- df_score(cols, j, models, score)
+  out
 })
 
 exp_imp_qntl_case1perm <- model_imp_scores |>

--- a/inst/get-testdata/exp_imp_qntl_untrained_lasomo/qntl-case1-no_missing-linear_pool.R
+++ b/inst/get-testdata/exp_imp_qntl_untrained_lasomo/qntl-case1-no_missing-linear_pool.R
@@ -4,6 +4,9 @@
 # ----------------------------------------------------------------------------
 # load the package to make its internal functions available
 devtools::load_all()
+source(system.file("get-testdata/helper-exp_imp-untrained.R",
+  package = "modelimportance"
+))
 # target data
 target_data_qntl <- readRDS(
   testthat::test_path("testdata/target_qntl.rds")
@@ -24,33 +27,7 @@ subsets <- lapply(1:n, function(x) combn(n, x, simplify = FALSE)) |>
 # data frame of all possible ensemble forecasts
 dat_all_ens <- purrr::map_dfr(
   subsets,
-  function(subset) {
-    get_modelsubset <- models[subset]
-    # index of the subsets list that is identical to the current subset, S
-    i <- Position(function(x) identical(x, subset), subsets)
-    # calculate the weight given to this subset when subset_wt="perm_based"
-    weight_perm <- 1 / ((n - 1) * choose(n - 1, length(get_modelsubset)))
-    # when the subset includes all indices, its weight is infinite
-    # replace it with NA (this value won't be used)
-    weight_perm <- ifelse(is.infinite(weight_perm), NA, weight_perm)
-    # calculate the weight when subset_wt="equal"
-    weight_eq <- 1
-    # reduced data including the models in the subset S
-    data_subset <- dat_qntl |>
-      filter(.data$model_id %in% get_modelsubset)
-    # build an ensemble forecast using the models in the subset S
-    ensemble_forecast <- linear_pool(data_subset,
-      model_id = paste0("ensemble_", i)
-    )
-    # add index and weight to the ensemble forecast
-    ens_dat <- ensemble_forecast |>
-      mutate(
-        subset_idx = i,
-        subset_wt_perm = weight_perm,
-        subset_wt_eq = weight_eq
-      )
-    ens_dat
-  }
+  function(subset) lp_ens_untrained_lasomo(models, subset, d = dat_qntl)
 )
 
 # score the ensemble forecasts
@@ -78,20 +55,7 @@ model_imp_scores <- furrr::future_map_dfr(1:n, function(j) {
   scores_by_subset <- map(cols, function(col) {
     purrr::map_dbl(
       set_incl_j_more,
-      function(k) {
-        # get elements of the subset that includes j
-        set_k <- subsets[[k]]
-        # index in 'subsets' list that include elements of set_k except for j
-        k1 <- which(sapply(subsets, setequal, set_k[set_k != j]))
-        # wis for the ensemble forecast including jth model
-        score_incl_j <- score_ens_all$wis[k]
-        # wis for the ensemble forecast not including jth model
-        score_not_incl_j <- score_ens_all$wis[k1]
-        # get the subset weight for the current subset
-        subset_weight <- score_ens_all[[col]][k1]
-        # jth model's marginal contribution multiplied by the subset weight
-        subset_weight * (-score_incl_j + score_not_incl_j)
-      }
+      function(k) wtd_marginal_cntrbt_qntl(k, j, score_ens_all, subsets, col)
     )
   })
 

--- a/inst/get-testdata/exp_imp_qntl_untrained_lasomo/qntl-case2-no_missing-simple-agg_mean.R
+++ b/inst/get-testdata/exp_imp_qntl_untrained_lasomo/qntl-case2-no_missing-simple-agg_mean.R
@@ -65,20 +65,8 @@ model_imp_scores <- furrr::future_map_dfr(1:n, function(j) {
   # accumulate the scores calculated by subsets
   score <- lapply(scores_by_subset, sum)
   # store the importance score for the jth model
-  map_dfr(cols, function(col) {
-    data.frame(
-      model_id = models[j],
-      subset_wt = col,
-      importance = score[[col]]
-    )
-  }) |>
-    # importance score for the jth model depending on the subset_wt option
-    mutate(
-      subset_wt = sub("^subset_wt_", "", subset_wt),
-      importance = ifelse(subset_wt == "perm", importance,
-        importance / (2^(n - 1) - 1)
-      )
-    )
+  out <- df_score(cols, j, models, score)
+  out
 })
 
 exp_imp_qntl_case2perm <- model_imp_scores |>

--- a/inst/get-testdata/exp_imp_qntl_untrained_lasomo/qntl-case2-no_missing-simple-agg_mean.R
+++ b/inst/get-testdata/exp_imp_qntl_untrained_lasomo/qntl-case2-no_missing-simple-agg_mean.R
@@ -28,7 +28,9 @@ subsets <- lapply(1:n, function(x) combn(n, x, simplify = FALSE)) |>
 dat_all_ens <- purrr::map_dfr(
   subsets,
   function(subset) {
-    simple_ens_untrained_lasomo(models, subset, d = dat_qntl, aggfun = "mean")
+    simple_ens_untrained_lasomo(models, subset, subsets,
+      d = dat_qntl, aggfun = "mean"
+    )
   }
 )
 

--- a/inst/get-testdata/exp_imp_qntl_untrained_lasomo/qntl-case2-no_missing-simple-agg_mean.R
+++ b/inst/get-testdata/exp_imp_qntl_untrained_lasomo/qntl-case2-no_missing-simple-agg_mean.R
@@ -4,6 +4,9 @@
 # ----------------------------------------------------------------------------
 # load the package to make its internal functions available
 devtools::load_all()
+source(system.file("get-testdata/helper-exp_imp-untrained.R",
+  package = "modelimportance"
+))
 # target data
 target_data_qntl <- readRDS(
   testthat::test_path("testdata/target_qntl.rds")
@@ -25,32 +28,7 @@ subsets <- lapply(1:n, function(x) combn(n, x, simplify = FALSE)) |>
 dat_all_ens <- purrr::map_dfr(
   subsets,
   function(subset) {
-    get_modelsubset <- models[subset]
-    # index of the subsets list that is identical to the current subset, S
-    i <- Position(function(x) identical(x, subset), subsets)
-    # calculate the weight given to this subset when subset_wt="perm_based"
-    weight_perm <- 1 / ((n - 1) * choose(n - 1, length(get_modelsubset)))
-    # when the subset includes all indices, its weight is infinite
-    # replace it with NA (this value won't be used)
-    weight_perm <- ifelse(is.infinite(weight_perm), NA, weight_perm)
-    # calculate the weight when subset_wt="equal"
-    weight_eq <- 1
-    # reduced data including the models in the subset S
-    data_subset <- dat_qntl |>
-      filter(.data$model_id %in% get_modelsubset)
-    # build an ensemble forecast using the models in the subset S
-    ensemble_forecast <- simple_ensemble(data_subset,
-      model_id = paste0("ensemble_", i),
-      agg_fun = "mean"
-    )
-    # add index and weight to the ensemble forecast
-    ens_dat <- ensemble_forecast |>
-      mutate(
-        subset_idx = i,
-        subset_wt_perm = weight_perm,
-        subset_wt_eq = weight_eq
-      )
-    ens_dat
+    simple_ens_untrained_lasomo(models, subset, d = dat_qntl, aggfun = "mean")
   }
 )
 
@@ -79,20 +57,7 @@ model_imp_scores <- furrr::future_map_dfr(1:n, function(j) {
   scores_by_subset <- map(cols, function(col) {
     purrr::map_dbl(
       set_incl_j_more,
-      function(k) {
-        # get elements of the subset that includes j
-        set_k <- subsets[[k]]
-        # index in 'subsets' list that include elements of set_k except for j
-        k1 <- which(sapply(subsets, setequal, set_k[set_k != j]))
-        # wis for the ensemble forecast including jth model
-        score_incl_j <- score_ens_all$wis[k]
-        # wis for the ensemble forecast not including jth model
-        score_not_incl_j <- score_ens_all$wis[k1]
-        # get the subset weight for the current subset
-        subset_weight <- score_ens_all[[col]][k1]
-        # jth model's marginal contribution multiplied by the subset weight
-        subset_weight * (-score_incl_j + score_not_incl_j)
-      }
+      function(k) wtd_marginal_cntrbt_qntl(k, j, score_ens_all, subsets, col)
     )
   })
 

--- a/inst/get-testdata/exp_imp_qntl_untrained_lasomo/qntl-case3-no_missing-simple-agg_median.R
+++ b/inst/get-testdata/exp_imp_qntl_untrained_lasomo/qntl-case3-no_missing-simple-agg_median.R
@@ -4,6 +4,9 @@
 # ----------------------------------------------------------------------------
 # load the package to make its internal functions available
 devtools::load_all()
+source(system.file("get-testdata/helper-exp_imp-untrained.R",
+  package = "modelimportance"
+))
 # target data
 target_data_qntl <- readRDS(
   testthat::test_path("testdata/target_qntl.rds")
@@ -25,32 +28,7 @@ subsets <- lapply(1:n, function(x) combn(n, x, simplify = FALSE)) |>
 dat_all_ens <- purrr::map_dfr(
   subsets,
   function(subset) {
-    get_modelsubset <- models[subset]
-    # index of the subsets list that is identical to the current subset, S
-    i <- Position(function(x) identical(x, subset), subsets)
-    # calculate the weight given to this subset when subset_wt="perm_based"
-    weight_perm <- 1 / ((n - 1) * choose(n - 1, length(get_modelsubset)))
-    # when the subset includes all indices, its weight is infinite
-    # replace it with NA (this value won't be used)
-    weight_perm <- ifelse(is.infinite(weight_perm), NA, weight_perm)
-    # calculate the weight when subset_wt="equal"
-    weight_eq <- 1
-    # reduced data including the models in the subset S
-    data_subset <- dat_qntl |>
-      filter(.data$model_id %in% get_modelsubset)
-    # build an ensemble forecast using the models in the subset S
-    ensemble_forecast <- simple_ensemble(data_subset,
-      model_id = paste0("ensemble_", i),
-      agg_fun = "median"
-    )
-    # add index and weight to the ensemble forecast
-    ens_dat <- ensemble_forecast |>
-      mutate(
-        subset_idx = i,
-        subset_wt_perm = weight_perm,
-        subset_wt_eq = weight_eq
-      )
-    ens_dat
+    simple_ens_untrained_lasomo(models, subset, d = dat_qntl, aggfun = "median")
   }
 )
 
@@ -79,20 +57,7 @@ model_imp_scores <- furrr::future_map_dfr(1:n, function(j) {
   scores_by_subset <- map(cols, function(col) {
     purrr::map_dbl(
       set_incl_j_more,
-      function(k) {
-        # get elements of the subset that includes j
-        set_k <- subsets[[k]]
-        # index in 'subsets' list that include elements of set_k except for j
-        k1 <- which(sapply(subsets, setequal, set_k[set_k != j]))
-        # wis for the ensemble forecast including jth model
-        score_incl_j <- score_ens_all$wis[k]
-        # wis for the ensemble forecast not including jth model
-        score_not_incl_j <- score_ens_all$wis[k1]
-        # get the subset weight for the current subset
-        subset_weight <- score_ens_all[[col]][k1]
-        # jth model's marginal contribution multiplied by the subset weight
-        subset_weight * (-score_incl_j + score_not_incl_j)
-      }
+      function(k) wtd_marginal_cntrbt_qntl(k, j, score_ens_all, subsets, col)
     )
   })
 

--- a/inst/get-testdata/exp_imp_qntl_untrained_lasomo/qntl-case3-no_missing-simple-agg_median.R
+++ b/inst/get-testdata/exp_imp_qntl_untrained_lasomo/qntl-case3-no_missing-simple-agg_median.R
@@ -65,20 +65,8 @@ model_imp_scores <- furrr::future_map_dfr(1:n, function(j) {
   # accumulate the scores calculated by subsets
   score <- lapply(scores_by_subset, sum)
   # store the importance score for the jth model
-  map_dfr(cols, function(col) {
-    data.frame(
-      model_id = models[j],
-      subset_wt = col,
-      importance = score[[col]]
-    )
-  }) |>
-    # importance score for the jth model depending on the subset_wt option
-    mutate(
-      subset_wt = sub("^subset_wt_", "", subset_wt),
-      importance = ifelse(subset_wt == "perm", importance,
-        importance / (2^(n - 1) - 1)
-      )
-    )
+  out <- df_score(cols, j, models, score)
+  out
 })
 
 exp_imp_qntl_case3perm <- model_imp_scores |>

--- a/inst/get-testdata/exp_imp_qntl_untrained_lasomo/qntl-case3-no_missing-simple-agg_median.R
+++ b/inst/get-testdata/exp_imp_qntl_untrained_lasomo/qntl-case3-no_missing-simple-agg_median.R
@@ -28,7 +28,9 @@ subsets <- lapply(1:n, function(x) combn(n, x, simplify = FALSE)) |>
 dat_all_ens <- purrr::map_dfr(
   subsets,
   function(subset) {
-    simple_ens_untrained_lasomo(models, subset, d = dat_qntl, aggfun = "median")
+    simple_ens_untrained_lasomo(models, subset, subsets,
+      d = dat_qntl, aggfun = "median"
+    )
   }
 )
 

--- a/inst/get-testdata/exp_imp_qntl_untrained_lasomo/qntl-case4-missing-simple-agg_mean.R
+++ b/inst/get-testdata/exp_imp_qntl_untrained_lasomo/qntl-case4-missing-simple-agg_mean.R
@@ -31,7 +31,7 @@ subsets <- lapply(1:n, function(x) combn(n, x, simplify = FALSE)) |>
 dat_all_ens <- purrr::map_dfr(
   subsets,
   function(subset) {
-    simple_ens_untrained_lasomo(models, subset,
+    simple_ens_untrained_lasomo(models, subset, subsets,
       d = sub_dat_qntl,
       aggfun = "mean"
     )

--- a/inst/get-testdata/exp_imp_qntl_untrained_lasomo/qntl-case4-missing-simple-agg_mean.R
+++ b/inst/get-testdata/exp_imp_qntl_untrained_lasomo/qntl-case4-missing-simple-agg_mean.R
@@ -4,6 +4,9 @@
 # ----------------------------------------------------------------------------
 # load the package to make its internal functions available
 devtools::load_all()
+source(system.file("get-testdata/helper-exp_imp-untrained.R",
+  package = "modelimportance"
+))
 # target data
 target_data_qntl <- readRDS(
   testthat::test_path("testdata/target_qntl.rds")
@@ -28,32 +31,10 @@ subsets <- lapply(1:n, function(x) combn(n, x, simplify = FALSE)) |>
 dat_all_ens <- purrr::map_dfr(
   subsets,
   function(subset) {
-    get_modelsubset <- models[subset]
-    # index of the subsets list that is identical to the current subset, S
-    i <- Position(function(x) identical(x, subset), subsets)
-    # calculate the weight given to this subset when subset_wt="perm_based"
-    weight_perm <- 1 / ((n - 1) * choose(n - 1, length(get_modelsubset)))
-    # when the subset includes all indices, its weight is infinite
-    # replace it with NA (this value won't be used)
-    weight_perm <- ifelse(is.infinite(weight_perm), NA, weight_perm)
-    # calculate the weight when subset_wt="equal"
-    weight_eq <- 1
-    # reduced data including the models in the subset S
-    data_subset <- sub_dat_qntl |>
-      filter(.data$model_id %in% get_modelsubset)
-    # build an ensemble forecast using the models in the subset S
-    ensemble_forecast <- simple_ensemble(data_subset,
-      model_id = paste0("ensemble_", i),
-      agg_fun = "mean"
+    simple_ens_untrained_lasomo(models, subset,
+      d = sub_dat_qntl,
+      aggfun = "mean"
     )
-    # add index and weight to the ensemble forecast
-    ens_dat <- ensemble_forecast |>
-      mutate(
-        subset_idx = i,
-        subset_wt_perm = weight_perm,
-        subset_wt_eq = weight_eq
-      )
-    ens_dat
   }
 )
 
@@ -82,20 +63,7 @@ model_imp_scores <- furrr::future_map_dfr(1:n, function(j) {
   scores_by_subset <- map(cols, function(col) {
     purrr::map_dbl(
       set_incl_j_more,
-      function(k) {
-        # get elements of the subset that includes j
-        set_k <- subsets[[k]]
-        # index in 'subsets' list that include elements of set_k except for j
-        k1 <- which(sapply(subsets, setequal, set_k[set_k != j]))
-        # wis for the ensemble forecast including jth model
-        score_incl_j <- score_ens_all$wis[k]
-        # wis for the ensemble forecast not including jth model
-        score_not_incl_j <- score_ens_all$wis[k1]
-        # get the subset weight for the current subset
-        subset_weight <- score_ens_all[[col]][k1]
-        # jth model's marginal contribution multiplied by the subset weight
-        subset_weight * (-score_incl_j + score_not_incl_j)
-      }
+      function(k) wtd_marginal_cntrbt_qntl(k, j, score_ens_all, subsets, col)
     )
   })
 

--- a/inst/get-testdata/exp_imp_qntl_untrained_lasomo/qntl-case4-missing-simple-agg_mean.R
+++ b/inst/get-testdata/exp_imp_qntl_untrained_lasomo/qntl-case4-missing-simple-agg_mean.R
@@ -71,20 +71,8 @@ model_imp_scores <- furrr::future_map_dfr(1:n, function(j) {
   # accumulate the scores calculated by subsets
   score <- lapply(scores_by_subset, sum)
   # store the importance score for the jth model
-  map_dfr(cols, function(col) {
-    data.frame(
-      model_id = models[j],
-      subset_wt = col,
-      importance = score[[col]]
-    )
-  }) |>
-    # importance score for the jth model depending on the subset_wt option
-    mutate(
-      subset_wt = sub("^subset_wt_", "", subset_wt),
-      importance = ifelse(subset_wt == "perm", importance,
-        importance / (2^(n - 1) - 1)
-      )
-    )
+  out <- df_score(cols, j, models, score)
+  out
 })
 
 exp_imp_qntl_case4perm <- model_imp_scores |>

--- a/inst/get-testdata/helper-exp_imp-untrained.R
+++ b/inst/get-testdata/helper-exp_imp-untrained.R
@@ -6,7 +6,7 @@
 # =============================================================================
 
 # 1-1) Build linear pool ensemble in LASOMO for untrained ensemble models
-lp_ens_untrained_lasomo <- function(models, subset, d) {
+lp_ens_untrained_lasomo <- function(models, subset, subsets, d) {
   get_modelsubset <- models[subset]
   # index of the subsets list that is identical to the current subset, S
   i <- Position(function(x) identical(x, subset), subsets)
@@ -36,7 +36,7 @@ lp_ens_untrained_lasomo <- function(models, subset, d) {
 
 
 # 1-2) Build simple ensemble in LASOMO for untrained ensemble models
-simple_ens_untrained_lasomo <- function(models, subset, d, aggfun) {
+simple_ens_untrained_lasomo <- function(models, subset, subsets, d, aggfun) {
   get_modelsubset <- models[subset]
   # index of the subsets list that is identical to the current subset, S
   i <- Position(function(x) identical(x, subset), subsets)

--- a/inst/get-testdata/helper-exp_imp-untrained.R
+++ b/inst/get-testdata/helper-exp_imp-untrained.R
@@ -1,0 +1,152 @@
+# =============================================================================
+# Helper functions to
+# 1) build ensemble forecasts for untrained ensemble models using the LASOMO
+# 2) calculate weighted marginal contributions of individual models
+# 3) store the importance score for a specific model
+# =============================================================================
+
+# 1-1) Build linear pool ensemble in LASOMO for untrained ensemble models
+lp_ens_untrained_lasomo <- function(models, subset, d) {
+  get_modelsubset <- models[subset]
+  # index of the subsets list that is identical to the current subset, S
+  i <- Position(function(x) identical(x, subset), subsets)
+  # calculate the weight given to this subset when subset_wt="perm_based"
+  weight_perm <- 1 / ((n - 1) * choose(n - 1, length(get_modelsubset)))
+  # when the subset includes all indices, its weight is infinite
+  # replace it with NA (this value won't be used)
+  weight_perm <- ifelse(is.infinite(weight_perm), NA, weight_perm)
+  # calculate the weight when subset_wt="equal"
+  weight_eq <- 1
+  # reduced data including the models in the subset S
+  data_subset <- d |>
+    filter(.data$model_id %in% get_modelsubset)
+  # build an ensemble forecast using the models in the subset S
+  ensemble_forecast <- linear_pool(data_subset,
+    model_id = paste0("ensemble_", i)
+  )
+  # add index and weight to the ensemble forecast
+  ens_dat <- ensemble_forecast |>
+    mutate(
+      subset_idx = i,
+      subset_wt_perm = weight_perm,
+      subset_wt_eq = weight_eq
+    )
+  ens_dat
+}
+
+
+# 1-2) Build simple ensemble in LASOMO for untrained ensemble models
+simple_ens_untrained_lasomo <- function(models, subset, d, aggfun) {
+  get_modelsubset <- models[subset]
+  # index of the subsets list that is identical to the current subset, S
+  i <- Position(function(x) identical(x, subset), subsets)
+  # calculate the weight given to this subset when subset_wt="perm_based"
+  weight_perm <- 1 / ((n - 1) * choose(n - 1, length(get_modelsubset)))
+  # when the subset includes all indices, its weight is infinite
+  # replace it with NA (this value won't be used)
+  weight_perm <- ifelse(is.infinite(weight_perm), NA, weight_perm)
+  # calculate the weight when subset_wt="equal"
+  weight_eq <- 1
+  # reduced data including the models in the subset S
+  data_subset <- d |>
+    filter(.data$model_id %in% get_modelsubset)
+  # build an ensemble forecast using the models in the subset S
+  ensemble_forecast <- simple_ensemble(data_subset,
+    model_id = paste0("ensemble_", i),
+    agg_fun = aggfun
+  )
+  # add index and weight to the ensemble forecast
+  ens_dat <- ensemble_forecast |>
+    mutate(
+      subset_idx = i,
+      subset_wt_perm = weight_perm,
+      subset_wt_eq = weight_eq
+    )
+  ens_dat
+}
+
+# ----------------------------------------------------------------------------
+# 2) weighted marginal contribution of the jth model to each subset
+# 2-1) output type: mean
+wtd_marginal_cntrbt_mean <- function(k, j, score_ens_all, subsets, col) {
+  # get elements of the subset that includes j
+  set_k <- subsets[[k]]
+  # index in 'subsets' list that include elements of set_k except for j
+  k1 <- which(sapply(subsets, setequal, set_k[set_k != j]))
+  # se_point for the ensemble forecast including jth model
+  score_incl_j <- score_ens_all$se_point[k]
+  # se_point for the ensemble forecast not including jth model
+  score_not_incl_j <- score_ens_all$se_point[k1]
+  # get the subset weight for the current subset
+  subset_weight <- score_ens_all[[col]][k1]
+  # jth model's marginal contribution multiplied by the subset weight
+  subset_weight * (-score_incl_j + score_not_incl_j)
+}
+
+# 2-2) output type: median
+wtd_marginal_cntrbt_median <- function(k, j, score_ens_all, subsets, col) {
+  # get elements of the subset that includes j
+  set_k <- subsets[[k]]
+  # index in 'subsets' list that include elements of set_k except for j
+  k1 <- which(sapply(subsets, setequal, set_k[set_k != j]))
+  # ae_point for the ensemble forecast including jth model
+  score_incl_j <- score_ens_all$ae_point[k]
+  # ae_point for the ensemble forecast not including jth model
+  score_not_incl_j <- score_ens_all$ae_point[k1]
+  # get the subset weight for the current subset
+  subset_weight <- score_ens_all[[col]][k1]
+  # jth model's marginal contribution multiplied by the subset weight
+  subset_weight * (-score_incl_j + score_not_incl_j)
+}
+
+# 2-3) output type: quantile
+wtd_marginal_cntrbt_qntl <- function(k, j, score_ens_all, subsets, col) {
+  # get elements of the subset that includes j
+  set_k <- subsets[[k]]
+  # index in 'subsets' list that include elements of set_k except for j
+  k1 <- which(sapply(subsets, setequal, set_k[set_k != j]))
+  # wis for the ensemble forecast including jth model
+  score_incl_j <- score_ens_all$wis[k]
+  # wis for the ensemble forecast not including jth model
+  score_not_incl_j <- score_ens_all$wis[k1]
+  # get the subset weight for the current subset
+  subset_weight <- score_ens_all[[col]][k1]
+  # jth model's marginal contribution multiplied by the subset weight
+  subset_weight * (-score_incl_j + score_not_incl_j)
+}
+
+# 2-4) output type: pmf
+wtd_marginal_cntrbt_pmf <- function(k, j, score_ens_all, subsets, col) {
+  # get elements of the subset that includes j
+  set_k <- subsets[[k]]
+  # index in 'subsets' list that include elements of set_k except for j
+  k1 <- which(sapply(subsets, setequal, set_k[set_k != j]))
+  # log_score for the ensemble forecast including jth model
+  score_incl_j <- score_ens_all$log_score[k]
+  # log_score for the ensemble forecast not including jth model
+  score_not_incl_j <- score_ens_all$log_score[k1]
+  # get the subset weight for the current subset
+  subset_weight <- score_ens_all[[col]][k1]
+  # jth model's marginal contribution multiplied by the subset weight
+  subset_weight * (-score_incl_j + score_not_incl_j)
+}
+
+
+# ----------------------------------------------------------------------------
+# 3) store the importance score for the jth model
+df_score <- function(cols, j, models, score) {
+  map_dfr(cols, function(col) {
+    data.frame(
+      model_id = models[j],
+      subset_wt = col,
+      importance = score[[col]]
+    )
+  }) |>
+    # importance score for the jth model depending on the subset_wt option
+    mutate(
+      subset_wt = sub("^subset_wt_", "", subset_wt),
+      importance = ifelse(subset_wt == "perm", importance,
+        importance / (2^(n - 1) - 1)
+      )
+    )
+}

--- a/inst/get-testdata/helper-exp_imp-untrained.R
+++ b/inst/get-testdata/helper-exp_imp-untrained.R
@@ -144,8 +144,8 @@ df_score <- function(cols, j, models, score) {
   }) |>
     # importance score for the jth model depending on the subset_wt option
     mutate(
-      subset_wt = sub("^subset_wt_", "", subset_wt),
-      importance = ifelse(subset_wt == "perm", importance,
+      subset_wt = sub("^subset_wt_", "", .data$subset_wt),
+      importance = ifelse(.data$subset_wt == "perm", importance,
         importance / (2^(n - 1) - 1)
       )
     )

--- a/inst/get-testdata/helper-exp_imp-untrained.R
+++ b/inst/get-testdata/helper-exp_imp-untrained.R
@@ -135,7 +135,7 @@ wtd_marginal_cntrbt_pmf <- function(k, j, score_ens_all, subsets, col) {
 # ----------------------------------------------------------------------------
 # 3) store the importance score for the jth model
 df_score <- function(cols, j, models, score) {
-  map_dfr(cols, function(col) {
+  purrr::map_dfr(cols, function(col) {
     data.frame(
       model_id = models[j],
       subset_wt = col,


### PR DESCRIPTION
 This PR addresses Issue #29. 

Functions related to some logic from `score_untrained()` have been created and saved in the `inst/get-testdata/helper-exp_imp-untrained.R` file. These functions are used in the test data generation scripts in `inst/get-testdata/exp_imp_mean(median, qntl, pmf)_untrained_lasomo` to:
- build ensemble forecasts for untrained ensemble models using LASOMO
- calculate weighted marginal contributions of individual models
- store the importance score for a specific model

