### PR TITLE
use `message()` instead of `cat()`

### DIFF
--- a/R/send_message.R
+++ b/R/send_message.R
@@ -38,9 +38,9 @@ send_message <- function(status, ...) {
   if (status %in% names(messages)) {
     msg <- messages[[status]]
     if (is.function(msg)) {
-      cat(msg(...))
+      message(msg(...))
     } else {
-      cat(msg)
+      message(msg)
     }
   } else {
     stop("Invalid status for send_message().")


### PR DESCRIPTION
This PR contains only one modification in the internal function `send_message()`:
- Replace `cat()` with `message()` to control message outputs if needed.